### PR TITLE
Allow configurable timeout for opening the connection

### DIFF
--- a/lib/sirportly/request.rb
+++ b/lib/sirportly/request.rb
@@ -37,6 +37,7 @@ module Sirportly
       end
 
       http = Net::HTTP.new(uri.host, uri.port)
+      http.open_timeout = ENV['NET_HTTP_OPEN_TIMOUT'] || 5
 
       if uri.scheme == 'https'
         http.use_ssl = true


### PR DESCRIPTION
Default to 5 seconds or accept value via environment variable `NET_HTTP_OPEN_TIMEOUT`
